### PR TITLE
chore: add contributor governance docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**info@blu-h.org**. All complaints will be reviewed and investigated promptly
+and fairly. All community leaders are obligated to respect the privacy and
+security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Blu-H MoM
+
+Thanks for your interest in contributing to the Model of Models (MoM) project at Blu-H! 🌊
+
+## Ways to contribute
+- Report bugs or suggest features via [Issues](../../issues)
+- Improve documentation
+- Submit code via pull requests
+
+## Reporting issues
+- Search existing issues (open **and** closed) first to avoid duplicates.
+- Use the issue templates where available.
+- Include steps to reproduce, expected vs. actual behaviour, and environment details.
+
+## Development workflow
+1. Fork the repository (external contributors) or create a branch (collaborators).
+2. Create a focused feature branch: `git checkout -b feat/short-description`.
+3. Make small, self-contained changes.
+4. Open a pull request against the default branch and fill in the PR template.
+5. Link the issue your PR addresses (e.g. `Closes #123`).
+
+See the repository `README` for setup and local-development instructions.
+
+## Style & expectations
+- Keep changes small and reviewable.
+- Match the existing code style.
+- Update docs when you change behaviour.
+
+## Code of Conduct
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Questions
+Reach the team at **info@blu-h.org**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security Policy
+
+## Reporting a vulnerability
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, email **info@blu-h.org** with:
+- a description of the issue,
+- steps to reproduce or a proof of concept,
+- any relevant logs or screenshots.
+
+We will acknowledge your report and aim to respond promptly. Please give us a reasonable opportunity to address the issue before any public disclosure.
+
+## Scope
+These projects include a prototype decision-support tool and supporting data/analysis. Please report anything that could expose credentials, user data, or compromise the data pipeline or hosting.


### PR DESCRIPTION
Adds the standard contributor/governance files to make this repo external-contributor ready:

- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, contact info@blu-h.org)
- `SECURITY.md` (report privately to info@blu-h.org)
- `.github/ISSUE_TEMPLATE/` (bug, feature, config)
- `.github/PULL_REQUEST_TEMPLATE.md`

Part of the MoM public-readiness review. **LICENSE is intentionally not included** — that decision is tracked separately (Blu-H/MoM-map#2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)